### PR TITLE
Fixed BC break #15 introduced in #13

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -63,9 +63,9 @@ class Module implements
             'aliases' => [
                 'lmcuser_laminas_db_adapter' => \Laminas\Db\Adapter\Adapter::class,
                 'lmcuser_register_form_hydrator' => 'lmcuser_user_hydrator',
-                'lmcuser_base_hydrator' => ClassMethodsHydrator::class
             ],
             'invokables' => [
+                'lmcuser_base_hydrator' => ClassMethodsHydrator::class,
             ],
             'factories' => [
                 'lmcuser_redirect_callback' => \LmcUser\Factory\Controller\RedirectCallbackFactory::class,

--- a/Module.php
+++ b/Module.php
@@ -63,9 +63,10 @@ class Module implements
             'aliases' => [
                 'lmcuser_laminas_db_adapter' => \Laminas\Db\Adapter\Adapter::class,
                 'lmcuser_register_form_hydrator' => 'lmcuser_user_hydrator',
+                'lmcuser_base_hydrator' => 'lmcuser_default_hydrator',
             ],
             'invokables' => [
-                'lmcuser_base_hydrator' => ClassMethodsHydrator::class,
+                'lmcuser_default_hydrator' => ClassMethodsHydrator::class,
             ],
             'factories' => [
                 'lmcuser_redirect_callback' => \LmcUser\Factory\Controller\RedirectCallbackFactory::class,


### PR DESCRIPTION
service manager does not have service named `ClassMethodsHydrator::class` this only exists in hydrators manager.