### PR TITLE
Remove dynamic property declaration

### DIFF
--- a/src/Authentication/Adapter/AdapterChainEvent.php
+++ b/src/Authentication/Adapter/AdapterChainEvent.php
@@ -97,7 +97,6 @@ class AdapterChainEvent extends Event
     public function setRequest(Request $request)
     {
         $this->setParam('request', $request);
-        $this->request = $request;
         return $this;
     }
 }


### PR DESCRIPTION
Line removed to addresses a deprecation warning for dynamic property access on PHP 8.2.
This property direct assignment is not used, not documented, nor tested (nor needed).

Fix #41 

