### PR TITLE
Fixed Test suite to remove PHP 8.2 deprecation notices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,18 @@ matrix:
     - php: 8.0
       env:
         - DEPS=latest
+    - php: 8.1
+      env:
+        - DEPS=lowest
+    - php: 8.1
+      env:
+        - DEPS=latest
+    - php: 8.2
+      env:
+        - DEPS=lowest
+    - php: 8.2
+      env:
+        - DEPS=latest
     - php: nightly
       env:
         - DEPS=lowest

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,39 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         verbose="true"
-         stopOnFailure="false"
-         processIsolation="false"
-         backupGlobals="false"
->
-    <testsuite name="LmcUser Test Suite">
-        <directory>./tests</directory>
-    </testsuite>
-    
-    <php>
-        <const name="DB_MYSQL_DSN" value="mysql:host=localhost;dbname=lmc_user" />
-        <const name="DB_MYSQL_USERNAME" value="root" />
-        <const name="DB_MYSQL_PASSWORD" value="" />
-        <const name="DB_MYSQL_SCHEMA" value="./data/schema.mysql.sql" />
-        
-        <const name="DB_SQLITE_DSN" value="sqlite::memory:" />
-        <const name="DB_SQLITE_USERNAME" value="" />
-        <const name="DB_SQLITE_PASSWORD" value="" />
-        <const name="DB_SQLITE_SCHEMA" value="./data/schema.sqlite.sql" />
-    </php>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <file>Module.php</file>
-        </whitelist>
-    </filter>
-    
-    <logging>
-        <log type="coverage-text" target="php://stdout"/>
-        <log type="coverage-clover" target="./build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" verbose="true" stopOnFailure="false" processIsolation="false" backupGlobals="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+      <file>Module.php</file>
+    </include>
+    <report>
+      <clover outputFile="./build/logs/clover.xml"/>
+      <text outputFile="php://stdout"/>
+    </report>
+  </coverage>
+  <testsuite name="LmcUser Test Suite">
+    <directory>./tests</directory>
+  </testsuite>
+  <php>
+    <const name="DB_MYSQL_DSN" value="mysql:host=localhost;dbname=lmc_user"/>
+    <const name="DB_MYSQL_USERNAME" value="root"/>
+    <const name="DB_MYSQL_PASSWORD" value=""/>
+    <const name="DB_MYSQL_SCHEMA" value="./data/schema.mysql.sql"/>
+    <const name="DB_SQLITE_DSN" value="sqlite::memory:"/>
+    <const name="DB_SQLITE_USERNAME" value=""/>
+    <const name="DB_SQLITE_PASSWORD" value=""/>
+    <const name="DB_SQLITE_SCHEMA" value="./data/schema.sqlite.sql"/>
+  </php>
+  <logging/>
 </phpunit>

--- a/tests/Authentication/Adapter/DbTest.php
+++ b/tests/Authentication/Adapter/DbTest.php
@@ -2,6 +2,7 @@
 
 namespace LmcUserTest\Authentication\Adapter;
 
+use Laminas\Crypt\Password\Bcrypt;
 use Laminas\EventManager\Event;
 use LmcUser\Authentication\Adapter\Db;
 use PHPUnit\Framework\TestCase;
@@ -198,6 +199,15 @@ class DbTest extends TestCase
         $this->options->expects($this->once())
             ->method('getPasswordCost')
             ->willReturn(4);
+
+        $bcrypt = new Bcrypt([
+            'cost' => 4,
+        ]);
+
+        $hash = $bcrypt->create('123456');
+        $this->user->expects($this->once())
+            ->method('getPassword')
+            ->willReturn($hash);
 
         $this->authEvent->expects($this->once())
             ->method('setCode')

--- a/tests/Mapper/UserTest.php
+++ b/tests/Mapper/UserTest.php
@@ -68,6 +68,16 @@ class UserTest extends TestCase
      */
     protected $mockedDbAdapterPlatform;
 
+    /**
+     * @var \Laminas\Db\Adapter\Driver\StatementInterface
+     */
+    protected $mockedDbAdapterStatement;
+
+    /**
+     * @var \Laminas\Db\Sql\Platform\Platform
+     */
+    protected $mockedDbSqlPlatform;
+
     public function setUp():void
     {
         $mapper = new Mapper;

--- a/tests/Service/UserTest.php
+++ b/tests/Service/UserTest.php
@@ -88,13 +88,14 @@ class UserTest extends TestCase
      */
     public function testRegisterWithUsernameAndDisplayNameUserStateDisabled()
     {
-        $expectArray = array('username' => 'LmcUser', 'display_name' => 'Zfc User');
+        $expectArray = array('username' => 'LmcUser', 'display_name' => 'Zfc User', 'password' => '123456');
 
         $user = $this->createMock('LmcUser\Entity\User');
         $user->expects($this->once())
             ->method('setPassword');
         $user->expects($this->once())
-            ->method('getPassword');
+            ->method('getPassword')
+            ->willReturn('123456');
         $user->expects($this->once())
             ->method('setUsername')
             ->with('LmcUser');
@@ -159,13 +160,14 @@ class UserTest extends TestCase
      */
     public function testRegisterWithDefaultUserStateOfZero()
     {
-        $expectArray = array('username' => 'LmcUser', 'display_name' => 'Zfc User');
+        $expectArray = array('username' => 'LmcUser', 'display_name' => 'Zfc User', 'password' => '123456');
 
         $user = $this->createMock('LmcUser\Entity\User');
         $user->expects($this->once())
             ->method('setPassword');
         $user->expects($this->once())
-            ->method('getPassword');
+            ->method('getPassword')
+            ->willReturn('123456');
         $user->expects($this->once())
             ->method('setUsername')
             ->with('LmcUser');
@@ -231,13 +233,14 @@ class UserTest extends TestCase
      */
     public function testRegisterWithUserStateDisabled()
     {
-        $expectArray = array('username' => 'LmcUser', 'display_name' => 'Zfc User');
+        $expectArray = array('username' => 'LmcUser', 'display_name' => 'Zfc User', 'password' => '123456');
 
         $user = $this->createMock('LmcUser\Entity\User');
         $user->expects($this->once())
             ->method('setPassword');
         $user->expects($this->once())
-            ->method('getPassword');
+            ->method('getPassword')
+            ->willReturn('123456');
         $user->expects($this->once())
             ->method('setUsername')
             ->with('LmcUser');


### PR DESCRIPTION
- Modified the Test suite to remove a few PHP 8.2 deprecation notices.
- Upated travis-ci to run test suite for PHP 8.1 and 8.2 (Travis-CI is not running due to lack of credits on free plan)
